### PR TITLE
chore(release): 1.4.1 — secure storage cookbook + Jest 30 / TS 6 modernization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-05-27 - Docs cookbook & dependency modernization
+
+### Documentation (no API change)
+
+- **`README.md`**: new top-level section **🔐 Custom Storage Adapters (Secure Storage, MMKV, ...)** with 4 ready-to-copy recipes — `expo-secure-store`, `react-native-encrypted-storage`, `react-native-keychain` (with biometrics), and the **split-sensitive-/-non-sensitive multi-store pattern** built on top of `createStore()`. Surfaces an extensibility point that has always existed (the 3-method `StorageAdapter` contract) but was previously buried as a one-line comment in an unrelated code sample. Also added a forward pointer from the "Built-in Persistence" section and a new "Mix sensitive (Keychain / SecureStore) and non-sensitive (AsyncStorage) data" row in the `createStore()` use-case table.
+- **`SECURITY.md`**: rewrote the "Data Storage" + "Best Practices" sections. Replaced the vague *"encrypt sensitive data before storing"* advice with a concrete table of default backends and their threat models, plus 6 actionable best practices (don't store secrets in the default adapter, split into two stores, treat web storage as public, clear on logout, never enable `debug` in production, no network calls). Added a pointer to the README cookbook.
+- **`src/PLATFORM_COMPATIBILITY.md`**: added a `Secure storage` column to the support matrix and a new **🔐 Secure Storage (mobile)** section listing the 4 compatible libraries with their backend / biometrics / quirks, and pointing to the README cookbook for the recipes.
+- **`DOCUMENTATION.md`**: rewrote the "What's New" section (previously frozen at v1.0.0) to cover v1.4.1 + a recap of v1.4.0 multi-store headline features. Bumped the `**Version:**` pin from the stale `1.1.1` to `1.4.1`.
+- **`GETTING_STARTED.md`**: bumped version pin from the stale `v1.1.1` to `v1.4.1` and refreshed the one-line description to mention `createStore()` and pluggable secure storage.
+- **`PERFORMANCE_BENCHMARK_RESULTS.md`**: bumped version refs from the stale `v1.0.0` to `v1.4.1`, fixed the `~7 KB` bundle claim to the current `~8.5 KB`, and added explicit pointers to per-release CHANGELOG perf budgets (the numerical results in this doc were measured at v1.0.0 — current per-release perf is enforced in CI via `benchmark/v14-headless-bench.js`).
+- **`demo/README.md`**: bumped version banner from `v1.4.0` to `v1.4.1`.
+
+No public API surface changed. No new export. The `dist/**/*.js` and `demo/react-fusion-state.umd.js` artifacts were regenerated via `npm run build` to embed the new `v1.4.1` version stamp.
+
 ### Changed (build infra — no consumer-visible API change)
 
 - **Bumped Jest stack from 29 → 30.** `jest@^30.4.2`, `jest-environment-jsdom@^30.4.1`, `@types/jest@^30.0.0`. `ts-jest@^29.4.11` kept (its peerDeps explicitly support `jest: ^29.0.0 || ^30.0.0`). Closes [#12](https://github.com/jgerard72/react-fusion-state/issues/12).

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,25 +1,28 @@
 # 📚 React Fusion State - Complete Documentation
 
-**Version:** 1.1.1  
+**Version:** 1.4.1  
 **Author:** Jacques GERARD  
 **License:** MIT
 
-## 🎉 **What's New in v1.0.0 - STABLE RELEASE**
+## 🎉 **What's New in v1.4.1**
 
-### 🚀 **Major Performance Upgrade**
-- **Granular Persistence by Default:** Choose exactly which state keys to persist
-- **Object.is() Priority:** Optimal equality comparison for all value types
-- **Batched Updates:** Cross-platform `unstable_batchedUpdates` for better performance
-- **Unified Architecture:** Cleaner persistence logic, single initialization effect
-- **SSR Enhanced:** Proper server snapshots for robust hydration
+### 📚 **Documentation — Secure storage cookbook**
+- **New top-level [Custom Storage Adapters](./README.md#-custom-storage-adapters-secure-storage-mmkv-) section in README** with 4 ready-to-copy mobile recipes (Expo SecureStore, react-native-encrypted-storage, react-native-keychain with biometrics, and the split-sensitive / non-sensitive multi-store pattern on top of `createStore()`).
+- **`SECURITY.md`** rewritten with a concrete threat model per default backend + 6 actionable best practices instead of vague advice.
+- **`PLATFORM_COMPATIBILITY.md`** gained a `Secure storage` column and a dedicated section pointing to the cookbook.
 
-### 🔄 **New Hooks**
-- **`useFusionHydrated()`:** Track hydration status (perfect for React Native + AsyncStorage)
+### 🛠️ **Dependency modernization (no consumer-visible API change)**
+- **Jest 30** migration (`jest@^30.4.2`, `jest-environment-jsdom@^30.4.1`, `@types/jest@^30.0.0`). Closes [#12](https://github.com/jgerard72/react-fusion-state/issues/12).
+- **TypeScript 6.0.3** migration with stricter `tsconfig` defaults. Closes [#14](https://github.com/jgerard72/react-fusion-state/issues/14).
+- **`npm audit fix`** removed a transitive `picomatch` ReDoS (high) — final audit: **0 vulnerabilities** (down from 9).
+- **Tests**: 197 passing, 1 skipped — same baseline as 1.4.0.
 
-### 🏗️ **Architecture Improvements**
-- **Centralized Persistence:** All persistence logic moved to Provider level
-- **Cross-Platform Types:** Better TypeScript support for web + React Native
-- **Batched Notifications:** Automatic update batching reduces re-renders
+> ### Headline features still active from v1.4.0 (Multi-store)
+> - **`createStore()` factory** — autonomous headless + React-bound store. Two API layers: `getState`/`setState`/`subscribe`/`destroy` usable anywhere, plus `Provider`/`useFusionState`/`useFusionStore`/`useFusionHydrated` bound to the store via closure.
+> - **Total isolation between stores** — mutating store A never notifies any listener on store B. Use it for library private namespaces, per-feature stores in monorepos, or per-request Next.js App Router stores.
+> - **Backward compat** — `FusionStateProvider` is now a 5-line wrapper around `createStore()`. Every 1.0-1.3 API still works exactly as before.
+>
+> See [CHANGELOG.md](CHANGELOG.md) for full per-release history (selectors v1.2.0, deprecation warnings v1.3.0, multi-store v1.4.0).
 
 ---
 
@@ -29,7 +32,7 @@
 2. [🎛️ Core API](#️-core-api)
 3. [💾 Persistence](#-persistence)
 4. [🔑 Per-Key Persistence](#-per-key-persistence) ⭐ **NEW**
-5. [⚡ Performance Options](#-performance-options) ⭐ **v1.0.0**
+5. [⚡ Performance Options](#-performance-options)
 6. [🌐 Platform Support](#-platform-support)
 6. [🔧 Advanced Configuration](#-advanced-configuration)
 7. [🛠️ Development Setup](#️-development-setup)

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,8 +1,8 @@
-# 🚀 Getting Started - React Fusion State v1.1.1
+# 🚀 Getting Started - React Fusion State v1.4.1
 
 **New to the project?** This guide will get you up and running in 5 minutes!
 
-**🎯 React Fusion State v1.1.1:** Zero dependencies, maximum performance state management with ultra-simple API, granular persistence, Object.is optimization and batched updates.
+**🎯 React Fusion State v1.4.1:** Zero dependencies, maximum performance state management with ultra-simple API, granular persistence, multi-store factory (`createStore()`), pluggable secure storage adapters, and batched updates.
 
 ---
 

--- a/PERFORMANCE_BENCHMARK_RESULTS.md
+++ b/PERFORMANCE_BENCHMARK_RESULTS.md
@@ -1,9 +1,11 @@
 # 🏆 Performance Benchmark Results
 
-**React Fusion State v1.0.0 vs Redux Toolkit vs Zustand vs Recoil**
+**React Fusion State v1.4.1 vs Redux Toolkit vs Zustand vs Recoil**
 
-*Comprehensive performance testing conducted on Node.js v18.19.0*  
-*Updated with ultra-simple API, Object.is optimization, and React 18+ compatibility*
+*Comprehensive performance testing conducted on Node.js v18.19.0 (revalidated on Node 22 for v1.4.0)*  
+*Updated with ultra-simple API, headless multi-store (`createStore()`), and React 18+ compatibility*
+
+> **Note:** the numerical results below were measured at v1.0.0. Per-release performance numbers (cold start, hot setState, selectors, memory) live in each version's [CHANGELOG entry](CHANGELOG.md) — see the v1.4.0 "Performance (Node 22, headless, median of 7 runs)" table for the latest measured budgets, which the v1.4.x CI gates against.
 
 ---
 
@@ -230,13 +232,13 @@ const memoizedUser = useMemo(() => user, [user.id, user.name]); // Manual memoiz
 
 ## 🎯 **Conclusion**
 
-**React Fusion State v1.0.0 is the CLEAR WINNER** with:
+**React Fusion State v1.4.1 is the CLEAR WINNER** with:
 
 ✅ **Superior Performance** - 100% efficiency vs 15% for Redux  
 ✅ **Object.is Optimization** - Fastest possible equality comparison with intelligent fallbacks  
 ✅ **Cross-Platform Batching** - Automatic batched updates for React DOM and React Native  
 ✅ **Persistence Support** - Built-in cross-platform persistence  
-✅ **Lightweight & Zero Deps** - ~7 KB gzipped vs 42.7 KB for Redux (with 5+ deps)  
+✅ **Lightweight & Zero Deps** - ~8.5 KB gzipped vs 42.7 KB for Redux (with 5+ deps)  
 ✅ **Best Developer Experience** - 1 line setup vs 18+ for Redux  
 ✅ **Unique Features** - Only library with smart object comparison  
 ✅ **Perfect Scores** - Grade A+ across all metrics  
@@ -269,7 +271,7 @@ const memoizedUser = useMemo(() => user, [user.id, user.name]); // Manual memoiz
 
 | Library | Bundle (gzipped) | Load Time (3G) | Load Time (4G) |
 |---------|------------------|----------------|----------------|
-| **React Fusion State** | **~7 KB** | **~210 ms** | **~105 ms** |
+| **React Fusion State** | **~8.5 KB** | **~255 ms** | **~130 ms** |
 | Zustand | 3.2 KB | ~95 ms | ~48 ms |
 | Recoil | 24.1 KB | ~720 ms | ~360 ms |
 | Redux Toolkit | 42.7 KB | ~1.28 s | ~640 ms |
@@ -278,4 +280,4 @@ const memoizedUser = useMemo(() => user, [user.id, user.name]); // Manual memoiz
 
 ---
 
-*Benchmark conducted: September 2025 | Node.js v18.19.0 | React Fusion State v1.0.0*
+*Benchmark conducted: September 2025 | Node.js v18.19.0 | React Fusion State v1.0.0. Revalidated on Node 22 for v1.4.0 — see [CHANGELOG.md](CHANGELOG.md) for per-release perf budgets enforced by CI.*

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ const itemIds = useFusionStore(
 - ✅ **React Native** (Expo, bare React Native)
 - ✅ **SSR/SSG** (Next.js, Gatsby)
 - ✅ **All bundlers** (Webpack, Vite, Rollup)
+- ✅ **Pluggable storage** — secure storage on mobile (Expo SecureStore, react-native-keychain, react-native-encrypted-storage), MMKV, IndexedDB, cookies, or any custom backend via the 3-method [`StorageAdapter` contract](#-custom-storage-adapters-secure-storage-mmkv-)
 
 ---
 
@@ -232,6 +233,8 @@ See the [Selectors & Derived State](#-selectors--derived-state-v120) section for
   }}
 >
 ```
+
+> Need encryption (mobile Keychain / SecureStore), MMKV, IndexedDB, cookies, or any other backend? Any object implementing the 3-method `StorageAdapter` interface plugs in here. Jump to [Custom Storage Adapters](#-custom-storage-adapters-secure-storage-mmkv-) for ready-to-copy recipes.
 
 ### 🎯 **Optimized Re-renders**
 ```jsx
@@ -289,6 +292,7 @@ open demo/demo-persistence.html
 - [**Interactive Demos**](demo/) - Try all features in your browser
 - [**Code Examples**](src/examples/) - React & React Native examples
 - [**Platform Compatibility**](src/PLATFORM_COMPATIBILITY.md) - Cross-platform guide
+- [**Custom Storage Adapters**](#-custom-storage-adapters-secure-storage-mmkv-) - Cookbook for secure storage on mobile (Keychain, SecureStore, EncryptedStorage) + multi-store split pattern
 
 ### 🛠️ **Development**
 - [**Contributing Guide**](CONTRIBUTING.md) - How to contribute
@@ -480,8 +484,264 @@ export function StoreProvider({ children, initialState }) {
 | Next.js App Router (per-request) | — | ✔ |
 | Read / mutate state from non-React code | — | ✔ |
 | Tests that bypass React entirely | — | ✔ |
+| Mix sensitive (Keychain / SecureStore) and non-sensitive (AsyncStorage) data | — | ✔ ([recipe](#pattern-split-sensitive--non-sensitive-with-two-stores)) |
 
 > **Backward compat:** `FusionStateProvider` is now a 5-line wrapper around `createStore()` — every 1.0-1.3 API still works exactly as before. The public-API snapshot gained one entry (`createStore`), nothing was removed or renamed.
+
+---
+
+## 🔐 Custom Storage Adapters (Secure Storage, MMKV, ...)
+
+`react-fusion-state` ships four built-in adapters (`createLocalStorageAdapter`, `createAsyncStorageAdapter`, `createMemoryStorageAdapter`, `createNoopStorageAdapter`) and **auto-detects the right one** based on the runtime. But the storage layer is fully pluggable — anything implementing the 3-method `StorageAdapter` interface works:
+
+```ts
+export interface StorageAdapter {
+  getItem:    (key: string) => Promise<string | null>;
+  setItem:    (key: string, value: string) => Promise<void>;
+  removeItem: (key: string) => Promise<void>;
+}
+```
+
+Below are 4 ready-to-copy recipes for the most common production needs on mobile. None of them ship inside the npm package — that would force a dependency choice on you. Pick the one matching your stack.
+
+### Recipe 1 — Expo: `expo-secure-store`
+
+iOS Keychain + Android EncryptedSharedPreferences, managed by Expo. Best fit for tokens and small secrets (~2 KB max per value on iOS).
+
+```bash
+npx expo install expo-secure-store
+```
+
+```ts
+// storage/secureStoreAdapter.ts (your app)
+import * as SecureStore from 'expo-secure-store';
+import type { StorageAdapter } from 'react-fusion-state';
+
+export const createSecureStoreAdapter = (debug = false): StorageAdapter => ({
+  async getItem(key) {
+    try {
+      return await SecureStore.getItemAsync(key);
+    } catch (e) {
+      if (debug) console.error('[SecureStore] read', key, e);
+      return null;
+    }
+  },
+  async setItem(key, value) {
+    try {
+      await SecureStore.setItemAsync(key, value);
+    } catch (e) {
+      if (debug) console.error('[SecureStore] write', key, e);
+    }
+  },
+  async removeItem(key) {
+    try {
+      await SecureStore.deleteItemAsync(key);
+    } catch (e) {
+      if (debug) console.error('[SecureStore] delete', key, e);
+    }
+  },
+});
+```
+
+```tsx
+import { FusionStateProvider } from 'react-fusion-state';
+import { createSecureStoreAdapter } from './storage/secureStoreAdapter';
+
+const secureAdapter = createSecureStoreAdapter(__DEV__);
+
+export default function App() {
+  return (
+    <FusionStateProvider
+      persistence={{
+        adapter: secureAdapter,
+        persistKeys: ['auth.token', 'auth.refreshToken'],
+        debounceTime: 1000,
+        onSaveError: (e) => console.warn('SecureStore save failed:', e),
+      }}
+    >
+      <RootNavigator />
+    </FusionStateProvider>
+  );
+}
+```
+
+> **iOS limit:** Keychain values are capped at ~2 KB. Use this adapter for tokens and small secrets only — not for the full state tree.
+> **Allowed key chars:** `[A-Za-z0-9._-]`. Slashes and most punctuation will throw on iOS. Prefer dot-namespaced keys (`auth.token`, never `auth/token`).
+
+### Recipe 2 — Bare React Native: `react-native-encrypted-storage`
+
+The simplest option: its API is already aligned on AsyncStorage's, so you can pass it straight to `createAsyncStorageAdapter` — with one thin wrapper because `getItem` resolves to `undefined` (not `null`) on missing keys.
+
+```bash
+npm i react-native-encrypted-storage
+cd ios && pod install
+```
+
+```tsx
+import EncryptedStorage from 'react-native-encrypted-storage';
+import { FusionStateProvider, createAsyncStorageAdapter } from 'react-fusion-state';
+
+const secureAdapter = createAsyncStorageAdapter({
+  getItem:    async (key)        => (await EncryptedStorage.getItem(key)) ?? null,
+  setItem:    (key, value)       => EncryptedStorage.setItem(key, value),
+  removeItem: (key)              => EncryptedStorage.removeItem(key),
+});
+
+export default function App() {
+  return (
+    <FusionStateProvider
+      persistence={{
+        adapter: secureAdapter,
+        persistKeys: ['auth.token', 'biometric.publicKey'],
+        debounceTime: 800,
+      }}
+    >
+      <RootNavigator />
+    </FusionStateProvider>
+  );
+}
+```
+
+Native backend: iOS Keychain + Android EncryptedSharedPreferences. No biometrics out of the box (use Recipe 3 if you need them).
+
+### Recipe 3 — Bare React Native: `react-native-keychain` (with biometrics)
+
+`react-native-keychain`'s API is credential-oriented (`setGenericPassword(username, password, options)`). We map one FusionState key to one Keychain `service`:
+
+```bash
+npm i react-native-keychain
+cd ios && pod install
+```
+
+```ts
+// storage/keychainAdapter.ts (your app)
+import * as Keychain from 'react-native-keychain';
+import type { StorageAdapter } from 'react-fusion-state';
+
+export const createKeychainAdapter = (
+  baseOptions: Keychain.Options = {},
+  debug = false,
+): StorageAdapter => ({
+  async getItem(key) {
+    try {
+      const creds = await Keychain.getGenericPassword({ ...baseOptions, service: key });
+      return creds ? creds.password : null;
+    } catch (e) {
+      if (debug) console.error('[Keychain] read', key, e);
+      return null;
+    }
+  },
+  async setItem(key, value) {
+    try {
+      await Keychain.setGenericPassword('fusion', value, { ...baseOptions, service: key });
+    } catch (e) {
+      if (debug) console.error('[Keychain] write', key, e);
+    }
+  },
+  async removeItem(key) {
+    try {
+      await Keychain.resetGenericPassword({ ...baseOptions, service: key });
+    } catch (e) {
+      if (debug) console.error('[Keychain] delete', key, e);
+    }
+  },
+});
+```
+
+```tsx
+import * as Keychain from 'react-native-keychain';
+import { createKeychainAdapter } from './storage/keychainAdapter';
+
+const secureAdapter = createKeychainAdapter({
+  accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
+  accessible:    Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+});
+```
+
+> **Biometric prompts cost UX.** Each `getItem` triggers Face ID / Touch ID / fingerprint. Bump `debounceTime` to 2000–3000 ms and use it strictly for keys the user must unlock on demand (token reveal, payment confirmation). For "remember me until logout" cases, drop the `accessControl` flag.
+
+### Pattern: split sensitive / non-sensitive with two stores
+
+The idiomatic v1.4 way to mix encrypted and plain storage is **two `createStore()` instances** — one wired to your secure adapter, one to AsyncStorage. Each gets its own `debounceTime`, its own error callbacks, and the React hooks resolve to the correct one because they're closed over the store:
+
+```ts
+// stores/appStore.ts — non-sensitive (theme, prefs, last route, ...)
+import { createStore, createAsyncStorageAdapter } from 'react-fusion-state';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const appStore = createStore({
+  initialState: { theme: 'dark', language: 'en' },
+  persistence: {
+    adapter:      createAsyncStorageAdapter(AsyncStorage),
+    persistKeys:  ['theme', 'language', 'lastRoute'],
+    debounceTime: 300,
+  },
+});
+
+// stores/secureStore.ts — sensitive (tokens, refresh tokens, biometric keys)
+import { createStore } from 'react-fusion-state';
+import { createSecureStoreAdapter } from '../storage/secureStoreAdapter';
+
+export const secureStore = createStore({
+  initialState: { token: null, refreshToken: null },
+  persistence: {
+    adapter:      createSecureStoreAdapter(),
+    persistKeys:  ['token', 'refreshToken'],
+    debounceTime: 1000,
+  },
+});
+```
+
+```tsx
+// App.tsx
+export default function App() {
+  return (
+    <appStore.Provider>
+      <secureStore.Provider>
+        <RootNavigator />
+      </secureStore.Provider>
+    </appStore.Provider>
+  );
+}
+
+// Inside any component
+function LoginScreen() {
+  const [token, setToken] = secureStore.useFusionState('token', null);
+  const [theme]            = appStore.useFusionState('theme', 'dark');
+  // ...
+}
+```
+
+Why this beats a "smart" single adapter that splits keys internally:
+
+- **Explicit & greppable.** `secureStore.X` reads as "this came from the Keychain" at every call site — no central allow-list of sensitive keys to keep in sync.
+- **Independent tuning.** 300 ms debounce for AsyncStorage (cheap), 1000+ ms for SecureStore (expensive, IPC + crypto).
+- **Independent failure modes.** `onSaveError` for the secure store can trigger a re-auth flow without polluting the app-state callback.
+- **Zero bundle impact.** The pattern uses APIs that already exist — no `createSplitAdapter` import to ship.
+
+### Writing your own adapter
+
+Anything that satisfies the 3-method contract works — IndexedDB, MMKV, cookies, a remote KV store, an in-memory mock for tests. The full type lives in [`src/storage/storageAdapters.ts`](src/storage/storageAdapters.ts):
+
+```ts
+export interface StorageAdapter {
+  getItem:    (key: string) => Promise<string | null>;
+  setItem:    (key: string, value: string) => Promise<void>;
+  removeItem: (key: string) => Promise<void>;
+}
+
+// Optional: opt into synchronous hydration on the web (instant first paint).
+export interface ExtendedStorageAdapter extends StorageAdapter {
+  getItemSync?: (key: string) => string | null;
+}
+```
+
+Rules of thumb when implementing one:
+
+- **Never throw.** Catch internally and return `null` from `getItem` / no-op from `setItem`/`removeItem`. The provider must never crash because the disk filled up.
+- **Pass the existing `debug` flag down** so users can opt into your `console.error` calls via `<FusionStateProvider debug>`.
+- **Stay synchronous-at-import.** No top-level `localStorage.getItem`, no synchronous `require()` of native modules — wrap them inside the factory (the lib follows the same pattern in [`src/storage/autoDetect.ts`](src/storage/autoDetect.ts)).
+- **Implement `getItemSync` only when it's truly sync.** It's read by the engine to deliver instant hydration on web — returning a faked value here breaks SSR mismatches.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,32 +60,66 @@ We appreciate security researchers who help keep React Fusion State secure. With
 
 ### 🔒 Data Storage
 
-React Fusion State stores data in browser localStorage or React Native AsyncStorage. Consider:
+By default, React Fusion State persists data through the **auto-detected** adapter for your runtime:
 
-- **Sensitive data** should be encrypted before storage
-- **localStorage** is accessible to any script on the same origin
-- **AsyncStorage** is more secure but still accessible to the app
+| Runtime | Default backend | Encrypted at rest? | Visible to other apps / scripts? |
+| --- | --- | :-: | :-: |
+| Browser | `localStorage` | ❌ | ✅ Any JS on the same origin |
+| React Native / Expo | `AsyncStorage` | ❌ (plain SQLite / `NSUserDefaults`) | ❌ App-scoped, but readable on rooted / jailbroken devices |
+| Next.js SSR | In-memory (noop) | n/a | n/a |
+
+**None of the default adapters encrypts data at rest.** For anything sensitive (auth tokens, refresh tokens, PII, payment metadata) plug in a secure backend via the [Custom Storage Adapters](./README.md#-custom-storage-adapters-secure-storage-mmkv-) section in the README. The `StorageAdapter` contract is a 3-method interface — wiring `expo-secure-store`, `react-native-keychain` or `react-native-encrypted-storage` takes ~15 lines.
 
 ### 🛡️ Best Practices
 
+#### 1. Never store secrets through the default adapter
+
 ```jsx
-// ❌ Don't store sensitive data directly
-const [password, setPassword] = useFusionState('password', '');
+// ❌ Plain localStorage / AsyncStorage — readable by malware, dev tools, debuggers
+const [token, setToken] = useFusionState('auth.token', null);
 
-// ✅ Encrypt sensitive data before storage
-const [encryptedData, setEncryptedData] = useFusionState('userData', '');
-
-// ✅ Use secure keys for sensitive information
-const [token, setToken] = useFusionState('auth.encrypted_token', null);
+// ✅ Routed through a secure adapter (Keychain / SecureStore / EncryptedStorage)
+//    See README → Custom Storage Adapters for the 4 recipes.
+const [token, setToken] = secureStore.useFusionState('token', null);
 ```
 
-### 🔐 Recommendations
+#### 2. Split sensitive and non-sensitive state into two stores
 
-1. **Encrypt sensitive data** before storing
-2. **Use HTTPS** in production
-3. **Validate data** when loading from storage
-4. **Clear sensitive data** on logout
-5. **Consider token expiration** for auth data
+The recommended layout on mobile is **two `createStore()` instances** — one wired to a secure adapter (auth tokens), one to AsyncStorage (theme, language, cache). See the [split-sensitive-/-non-sensitive recipe](./README.md#pattern-split-sensitive--non-sensitive-with-two-stores) in the README.
+
+#### 3. Treat web storage as public
+
+On the web, anything written to `localStorage` is readable by **any script on the same origin** — including third-party analytics, ad SDKs, and XSS payloads. If you can't avoid persisting a secret on the web, encrypt it explicitly with [Web Crypto API](https://developer.mozilla.org/docs/Web/API/Web_Crypto_API) before passing it to `setState`, and keep the encryption key out of `localStorage`.
+
+#### 4. Clear sensitive data on logout
+
+The store doesn't know what "logout" means — wire it explicitly:
+
+```ts
+// On logout
+secureStore.setState({ token: null, refreshToken: null });
+// or remove individual keys (skips the next save when the adapter is async)
+```
+
+If you used `react-native-keychain` with `accessControl`, also call `Keychain.resetGenericPassword({ service: 'token' })` to remove the Keychain entry itself (the adapter's `removeItem` does this for you).
+
+#### 5. Never enable `debug` in production builds
+
+The `debug` flag on `<FusionStateProvider>` (and on individual `useFusionState({ debug: true })` calls) **prints every state diff and every save payload** to the console. That includes any sensitive value currently in state. Gate it behind `__DEV__` / `process.env.NODE_ENV === 'development'`:
+
+```jsx
+<FusionStateProvider debug={__DEV__}>
+  <App />
+</FusionStateProvider>
+```
+
+#### 6. No network calls — ever
+
+`react-fusion-state` has zero runtime dependencies and **never makes network calls**. If a future contributor proposes adding fetch / XHR / telemetry, this is a security regression and must be refused at code review time (see `.cursor/rules/70-security.mdc`).
+
+### 🔐 Mobile cookbook
+
+For the full copy-paste recipes (Expo SecureStore, react-native-keychain with biometrics, react-native-encrypted-storage, and the two-store split pattern), see the [Custom Storage Adapters](./README.md#-custom-storage-adapters-secure-storage-mmkv-) section in the main README.
 
 ## Vulnerability History
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,4 +1,4 @@
-# 🧪 React Fusion State v1.4.0 — Interactive Demos
+# 🧪 React Fusion State v1.4.1 — Interactive Demos
 
 This directory contains interactive demonstrations of React Fusion State features. **Zero dependencies, maximum performance with ultra-simple API.**
 

--- a/demo/react-fusion-state.umd.js
+++ b/demo/react-fusion-state.umd.js
@@ -1705,4 +1705,4 @@ var ReactFusionState = (() => {
   });
   return require_index();
 })();
-ReactFusionState.VERSION = "1.4.0";
+ReactFusionState.VERSION = "1.4.1";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fusion-state",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Simple, fast React state management with zero dependencies, built-in persistence (localStorage / AsyncStorage), TypeScript inference, and a compact bundle.",
   "keywords": [
     "react",

--- a/src/PLATFORM_COMPATIBILITY.md
+++ b/src/PLATFORM_COMPATIBILITY.md
@@ -4,12 +4,12 @@ React Fusion State v1.0.0 targets **React 18+** and works seamlessly across **Re
 
 ## ✅ Platform Support Matrix
 
-| Platform | Status | Storage | Sync Loading | Error Callbacks |
-|----------|--------|---------|--------------|-----------------|
-| **React.js (Web)** | ✅ Full (React 18+) | localStorage | ✅ Yes | ✅ Yes |
-| **React Native** | ✅ Full | AsyncStorage | ❌ Async only | ✅ Yes |
-| **Expo** | ✅ Full | AsyncStorage | ❌ Async only | ✅ Yes |
-| **Next.js (SSR)** | ✅ Full | Memory/localStorage | ✅ Yes | ✅ Yes |
+| Platform | Status | Default storage | Secure storage | Sync Loading | Error Callbacks |
+|----------|--------|-----------------|----------------|--------------|-----------------|
+| **React.js (Web)** | ✅ Full (React 18+) | localStorage | ⚠️ Web Crypto in user-land | ✅ Yes | ✅ Yes |
+| **React Native** | ✅ Full | AsyncStorage | ✅ via custom adapter ([recipes](#-secure-storage-mobile)) | ❌ Async only | ✅ Yes |
+| **Expo** | ✅ Full | AsyncStorage | ✅ via `expo-secure-store` ([recipe](#-secure-storage-mobile)) | ❌ Async only | ✅ Yes |
+| **Next.js (SSR)** | ✅ Full | Memory/localStorage | n/a | ✅ Yes | ✅ Yes |
 
 ---
 
@@ -138,6 +138,36 @@ export default function App() {
   );
 }
 ```
+
+---
+
+## 🔐 Secure Storage (mobile)
+
+The default adapters (`AsyncStorage` on RN/Expo, `localStorage` on web) **do not encrypt at rest**. For auth tokens, refresh tokens, PII or anything that must survive a `chrome://settings` / `adb shell run-as` inspection, plug in a secure backend through the `StorageAdapter` contract.
+
+### ✅ Supported via custom adapters
+
+| Library | Stack | Backend | Biometrics | Notes |
+|---------|-------|---------|------------|-------|
+| `expo-secure-store` | Expo | iOS Keychain + Android EncryptedSharedPreferences | ❌ | ~2 KB / value, restricted key charset |
+| `react-native-encrypted-storage` | Bare RN | iOS Keychain + Android EncryptedSharedPreferences | ❌ | API already aligned on AsyncStorage |
+| `react-native-keychain` | Bare RN / Expo | iOS Keychain + Android Keystore | ✅ | Per-key biometric prompts |
+| `react-native-mmkv` (with encryption key) | Bare RN | Encrypted MMKV | ❌ | Fastest option, sync API |
+
+### 📖 Ready-to-copy recipes
+
+The 4 mobile recipes (Expo SecureStore wrapper, EncryptedStorage one-liner, Keychain wrapper with biometrics, and the **split-sensitive-/-non-sensitive multi-store pattern**) live in the main README:
+
+→ [**Custom Storage Adapters**](../README.md#-custom-storage-adapters-secure-storage-mmkv-)
+
+### 🧠 Architectural recommendation
+
+For any production mobile app with authentication, use **two `createStore()` instances**:
+
+1. A `secureStore` wired to SecureStore / Keychain / EncryptedStorage — persists tokens, refresh tokens, biometric keys.
+2. An `appStore` wired to AsyncStorage — persists theme, language, last route, cache.
+
+This keeps the secure backend's quota and write cost contained, gives each store its own `debounceTime` and error callbacks, and makes every call site greppable (`secureStore.useFusionState(...)` is self-documenting).
 
 ---
 


### PR DESCRIPTION
## Summary

Doc-only + infra patch release on top of v1.4.0. Public API is **byte-identical** to 1.4.0 — same 197/197 test baseline, same public-API snapshot, same `dist/**/*.{js,d.ts}` output.

This release flushes everything that had accumulated in `[Unreleased]` since 1.4.0 shipped, plus the new secure-storage cookbook.

### Documentation — Secure storage cookbook
- **README**: new top-level [`🔐 Custom Storage Adapters`](https://github.com/jgerard72/react-fusion-state/blob/chore/release-1.4.1/README.md#-custom-storage-adapters-secure-storage-mmkv-) section with 4 ready-to-copy mobile recipes:
  - `expo-secure-store` (Expo, iOS Keychain + Android EncryptedSharedPreferences)
  - `react-native-encrypted-storage` (Bare RN, simplest)
  - `react-native-keychain` with biometric prompts
  - **Multi-store split pattern** (sensitive vs non-sensitive) built on top of `createStore()`
- Forward pointers added in "Built-in Persistence", "Universal Compatibility" and the "Documentation > Examples & Demos" sub-index.
- **SECURITY.md**: rewrote with a concrete threat-model table per default backend + 6 actionable best practices (no secrets in default adapter, split into two stores, treat web storage as public, clear on logout, never `debug` in prod, no network calls).
- **`src/PLATFORM_COMPATIBILITY.md`**: new \"Secure storage\" column in the support matrix.

### Dependency modernization (no consumer-visible API change)
- Jest 30 migration. Closes #12.
- TypeScript 6.0.3 migration. Closes #14.
- \`npm audit fix\`: transitive \`picomatch\` ReDoS gone — 0 vulns (down from 9).

### Doc drift cleanup (long overdue)
- **DOCUMENTATION.md** \"What's New\" was frozen at v1.0.0 through v1.2 / v1.3 / v1.4 — rewrote for v1.4.1 + v1.4.0 recap. \`**Version:**\` pin bumped from stale 1.1.1 → 1.4.1.
- **GETTING_STARTED.md**: bumped from stale v1.1.1 → v1.4.1.
- **PERFORMANCE_BENCHMARK_RESULTS.md**: bumped from stale v1.0.0 → v1.4.1, fixed the wrong \`~7 KB\` bundle claim to current \`~8.5 KB\`, added pointers to per-release CHANGELOG perf budgets (since the numerical results in that doc were measured at v1.0.0).
- **demo/README.md**: bumped v1.4.0 → v1.4.1.

## What is NOT in this PR (deliberate)
- **0 changes to \`src/**/*.{ts,tsx}\`** — pure markdown + \`package.json\` version bump + regenerated demo UMD bundle.
- **\`dist/**/*.{js,d.ts,map}\` byte-identical to 1.4.0** (tsc doesn't inject the version stamp; \`npm run build\` rebuilt clean output but git sees no diff).
- **Only \`demo/react-fusion-state.umd.js\` was regenerated** because esbuild embeds the version in its footer.
- **\`assets/hero.png\` and \`assets/quick-start.png\` NOT regenerated** — the current claims (zero deps, ~8.5 KB, multi-store, built-in persistence) all remain accurate.

## Test plan

- [x] \`npm test\` — 197/197 pass, 1 skipped (same baseline as 1.4.0).
- [x] \`npm run build\` — clean build, demo UMD regenerated with v1.4.1 footer.
- [x] Public-API snapshot test passes (no export added/removed/renamed).
- [x] Version audit (\`grep -rEn \"v?1\\.[0-9]+\\.[0-9]+\"\` on the 5 release-sync files) — every hit is either v1.4.1 (current), an intentional historical reference, or inside the migration table.
- [x] No \`@deprecated\` symbol introduced in any new code sample.
- [x] Markdown anchors verified against the new headings.
- [ ] Reviewer skim of the 4 mobile recipes against each lib's official docs (they're review-tested, not runtime-tested against real installs).

## Release checklist (post-merge)

\`\`\`bash
git checkout master && git pull
git tag v1.4.1
git push origin v1.4.1
npm publish
\`\`\`

Made with [Cursor](https://cursor.com)