### PR TITLE
docs: rewrite README for international audience (PR 4.1)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,269 @@
+# react-fusion-state
+
+[![npm version](https://img.shields.io/npm/v/react-fusion-state.svg)](https://www.npmjs.com/package/react-fusion-state)
+[![license: MIT](https://img.shields.io/npm/l/react-fusion-state.svg)](https://github.com/jgerard72/react-fusion-state)
+
+> Bibliothèque légère pour l'état global dans React et React Native, avec une API proche de `useState`.
+
+[English](./README.md)
+
+## Pourquoi react-fusion-state ?
+
+- **API proche de `useState`** — tuples `[value, setValue]` et updaters fonctionnels
+- **État global** — partage de valeurs entre composants via des clés string
+- **Persistance intégrée** — stockage optionnel pour le Web et React Native
+- **React + React Native** — mêmes hooks sur les deux plateformes
+- **Zéro dépendance runtime** — aucun middleware ni package supplémentaire
+- **TypeScript-first** — les types sont inclus dans le package
+
+## Installation
+
+```bash
+npm install react-fusion-state
+```
+
+Nécessite `react` >= 18. `react-dom` est optionnel (Web uniquement).
+
+```bash
+yarn add react-fusion-state
+```
+
+## Démarrage rapide
+
+```tsx
+import { FusionStateProvider, useFusionState } from 'react-fusion-state';
+
+function Compteur() {
+  const [count, setCount] = useFusionState('counter', 0);
+
+  return (
+    <button onClick={() => setCount(c => c + 1)}>{count}</button>
+  );
+}
+
+function App() {
+  return (
+    <FusionStateProvider>
+      <Compteur />
+    </FusionStateProvider>
+  );
+}
+```
+
+Tout composant sous le même provider peut lire ou modifier `'counter'` avec `useFusionState('counter', …)`.
+
+## Concepts clés
+
+### Clés globales
+
+L'état est stocké sous des clés string uniques (par ex. `'counter'`, `'user.settings'`). Les composants qui utilisent la même clé partagent une seule valeur.
+
+### Sémantique de la valeur initiale
+
+Le second argument de `useFusionState` initialise la clé **uniquement si elle n'existe pas déjà** dans l'état global. Si un autre composant a déjà initialisé la clé, les appels suivants reçoivent la valeur existante. L'argument initial n'est pas réappliqué à chaque rendu.
+
+### Portée du provider
+
+`<FusionStateProvider>` possède un arbre d'état global. Enveloppez votre application (ou un sous-arbre) une fois. Les hooks doivent être appelés à l'intérieur d'un provider.
+
+## Fonctionnalités
+
+- État global partagé avec une API minimale
+- Persistance optionnelle (`localStorage` sur le Web ; adaptateurs sur React Native)
+- Journalisation debug pour le développement (prop `debug`)
+- Hooks composés pour les cas courants (`useToggle`, `useCounter`, `useFormState`, …)
+- Interface `StorageAdapter` pour des backends personnalisés
+
+## Aperçu de l'API
+
+| Export | Type | Description |
+| --- | --- | --- |
+| `useFusionState` | Hook | S'abonner à une clé globale ; retourne `[value, setValue]` |
+| `FusionStateProvider` | Composant | Provider racine de l'état global |
+| `useGlobalState` | Hook | Accéder au contexte d'état global complet |
+| `useFusionStateLog` | Hook | Observer des portions d'état pour le debug |
+| `usePersistentState` | Hook | Comme `useFusionState`, préfixe les clés avec `persist.` |
+| `useFrequentState` | Hook | Mises à jour fréquentes avec `skipLocalState: true` |
+| `useFormState` | Hook | Objet formulaire avec mise à jour par champ et reset |
+| `useCounter` | Hook | Compteur avec incrément, décrément et set |
+| `useToggle` | Hook | Booléen avec toggle et set |
+| `createLocalStorageAdapter` | Fonction | Adaptateur Web `localStorage` |
+| `createMemoryStorageAdapter` | Fonction | Adaptateur mémoire (tests, sessions éphémères) |
+| `createNoopStorageAdapter` | Fonction | Adaptateur no-op (fallback SSR) |
+| `detectBestStorageAdapter` | Fonction | Choisir le meilleur adaptateur pour le runtime |
+| `NoopStorageAdapter` | Fonction | Alias déprécié de `createNoopStorageAdapter` |
+| `formatErrorMessage` | Fonction | Remplacer les placeholders dans les messages d'erreur |
+| `debounce` | Fonction | Debounce d'une fonction |
+| `simpleDeepEqual` | Fonction | Égalité profonde basée sur JSON |
+| `FusionStateErrorMessages` | Enum | Modèles de messages d'erreur stables |
+| `FusionStateProviderProps` | Type | Props de `FusionStateProvider` |
+| `UseFusionStateOptions` | Type | Options par hook (`skipLocalState`, …) |
+| `GlobalState` | Type | Type de l'état global |
+| `SetStateAction` | Type | Valeur ou fonction updater |
+| `StateUpdater` | Type | Setter retourné par `useFusionState` |
+| `GlobalFusionStateContextType` | Type | Valeur de contexte de `useGlobalState` |
+| `FusionStatePersistenceProp` | Type | Formes acceptées de la prop `persistence` |
+| `SimplePersistenceConfig` | Type | Configuration de persistance simplifiée |
+| `PersistenceConfig` | Type | Configuration de persistance complète |
+| `PersistenceKeys` | Type | Formes de `persistKeys` (config simple) |
+| `PersistenceKeysConfig` | Type | Formes de `persistKeys` (config complète) |
+| `PersistenceKeyFilter` | Type | Prédicat de filtrage des clés persistées |
+| `StorageAdapter` | Type | Interface de backend de stockage |
+| `FusionStateLogOptions` | Type | Options de `useFusionStateLog` |
+| `FusionStateLogSnapshot` | Type | Snapshot retourné par `useFusionStateLog` |
+| `FusionStateLogKey` | Type | Identifiant de clé pour le logging |
+
+## Persistance
+
+La persistance est optionnelle. Passez une prop `persistence` à `FusionStateProvider` :
+
+```jsx
+// Activer la persistance avec les valeurs par défaut
+<FusionStateProvider persistence={true}>
+  <App />
+</FusionStateProvider>
+
+// Persister uniquement certaines clés
+<FusionStateProvider persistence={['user', 'theme']}>
+  <App />
+</FusionStateProvider>
+```
+
+Quand `persistence={true}` et qu'aucun filtre de clés n'est configuré, seules les clés préfixées par `persist.` sont sauvegardées par défaut. Utilisez `usePersistentState` ou préfixez vos clés manuellement.
+
+Pour les adaptateurs, le debounce, la sauvegarde/chargement personnalisés et React Native, voir **[PERSISTENCE.md](./PERSISTENCE.md)**.
+
+## TypeScript
+
+Les types sont inclus dans le package publié (`dist/index.d.ts`). Aucune installation `@types/*` n'est nécessaire.
+
+- Inférence générique : `useFusionState('count', 0)` infère `number`
+- Génériques explicites : `useFusionState<User>('user', { name: '', email: '' })`
+- Props du provider, configuration de persistance et adaptateurs entièrement typés
+- Types publics exportés (`StorageAdapter`, `PersistenceConfig`, `StateUpdater`, …) disponibles pour votre code
+
+## React Native
+
+React Fusion State fonctionne avec React Native en utilisant les mêmes hooks et le même provider.
+
+```jsx
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+import { FusionStateProvider, useFusionState } from 'react-fusion-state';
+
+function NavigationScreen() {
+  const [screenData, setScreenData] = useFusionState('navigation.data', {});
+
+  const navigateWithData = () => {
+    setScreenData({ userId: 123, lastVisited: new Date() });
+    // …puis naviguer vers l'écran suivant
+  };
+
+  return (
+    <View>
+      <Button title="Aller à l'écran Profil" onPress={navigateWithData} />
+    </View>
+  );
+}
+
+function ProfileScreen() {
+  const [screenData] = useFusionState('navigation.data', {});
+
+  return (
+    <View>
+      <Text>ID utilisateur: {screenData.userId}</Text>
+      <Text>Dernière visite: {screenData.lastVisited?.toString()}</Text>
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <FusionStateProvider
+      persistence={true}
+      initialState={{
+        'app.version': '1.0.0',
+        'user.settings': { notifications: true },
+      }}
+    >
+      {/* Votre navigation ou composants ici */}
+    </FusionStateProvider>
+  );
+}
+```
+
+### Notes React Native
+
+- **Persistance** — passez un adaptateur de stockage explicitement sur React Native si besoin ; voir [PERSISTENCE.md](./PERSISTENCE.md)
+- **Partage entre écrans** — évite de faire transiter les props dans la navigation
+- **État stable** — les valeurs survivent au démontage et remontage des écrans dans le même provider
+
+## Exemples
+
+### Mode debug
+
+```jsx
+<FusionStateProvider debug={true}>
+  <App />
+</FusionStateProvider>
+```
+
+Évitez d'activer `debug` en production — les logs peuvent contenir des données utilisateur.
+
+### Exemple complet (thème)
+
+```jsx
+import React from 'react';
+import { FusionStateProvider, useFusionState } from 'react-fusion-state';
+
+function ThemeToggle() {
+  const [theme, setTheme] = useFusionState('theme', 'light');
+
+  return (
+    <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
+      {theme === 'light' ? '🌙' : '☀️'}
+    </button>
+  );
+}
+
+function ThemedComponent() {
+  const [theme] = useFusionState('theme', 'light');
+
+  return (
+    <div
+      style={{
+        background: theme === 'light' ? '#fff' : '#333',
+        color: theme === 'light' ? '#333' : '#fff',
+        padding: '20px',
+      }}
+    >
+      <h2>Thème: {theme}</h2>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <FusionStateProvider
+      initialState={{ version: '1.0' }}
+      persistence={true}
+      debug={process.env.NODE_ENV === 'development'}
+    >
+      <div>
+        <ThemeToggle />
+        <ThemedComponent />
+      </div>
+    </FusionStateProvider>
+  );
+}
+
+export default App;
+```
+
+## Contribuer
+
+Issues et pull requests sont les bienvenues sur [GitHub](https://github.com/jgerard72/react-fusion-state).
+
+## Licence
+
+MIT

--- a/readme.md
+++ b/readme.md
@@ -1,166 +1,224 @@
-# React Fusion State
+# react-fusion-state
 
-Une bibliothèque simple et légère pour gérer l'état global de vos applications React.
+[![npm version](https://img.shields.io/npm/v/react-fusion-state.svg)](https://www.npmjs.com/package/react-fusion-state)
+[![license: MIT](https://img.shields.io/npm/l/react-fusion-state.svg)](https://github.com/jgerard72/react-fusion-state)
+
+> A lightweight library for global state in React and React Native, with an API that mirrors `useState`.
+
+[Français](./README.fr.md)
+
+## Why react-fusion-state?
+
+- **Familiar `useState` API** — `[value, setValue]` tuples and functional updaters
+- **Global state** — share values across components with string keys
+- **Built-in persistence** — optional storage for Web and React Native
+- **React + React Native** — same hooks on both platforms
+- **Zero runtime dependencies** — no middleware or extra packages required
+- **TypeScript-first** — types ship with the package
 
 ## Installation
 
 ```bash
 npm install react-fusion-state
-# ou
+```
+
+Requires `react` >= 18. `react-dom` is optional (Web only).
+
+```bash
 yarn add react-fusion-state
 ```
 
-## Fonctionnalités
+## Quick Start
 
-- 🚀 **Léger et rapide** - Moins de 2KB (minifié + gzippé)
-- 🔄 **API familière** - Similaire à useState de React
-- 🌐 **État global partagé** - Communication facile entre composants
-- 💾 **Persistance automatique** - Sauvegarde optionnelle de l'état
-- 📱 **Compatible React Native** - Fonctionne aussi sur mobile
+```tsx
+import { FusionStateProvider, useFusionState } from 'react-fusion-state';
 
-## Utilisation
+function Counter() {
+  const [count, setCount] = useFusionState('counter', 0);
 
-### 1. Enveloppez votre application avec le provider
-
-```jsx
-import { FusionStateProvider } from 'react-fusion-state';
+  return (
+    <button onClick={() => setCount(c => c + 1)}>{count}</button>
+  );
+}
 
 function App() {
   return (
     <FusionStateProvider>
-      <VotreApplication />
+      <Counter />
     </FusionStateProvider>
   );
 }
 ```
 
-### 2. Utilisez l'état global avec useFusionState
+Any component under the same provider can read or update `'counter'` with `useFusionState('counter', …)`.
+
+## Core Concepts
+
+### Global keys
+
+State is stored under unique string keys (for example `'counter'`, `'user.settings'`). Components that use the same key share one value.
+
+### Initial value semantics
+
+The second argument to `useFusionState` seeds the key **only when it is not already in global state**. If another component initialized the key first, later callers receive the existing value. The initial argument is not re-applied on re-render.
+
+### Provider scope
+
+`<FusionStateProvider>` owns one global state tree. Wrap your app (or a subtree) once. Hooks must run inside a provider.
+
+## Features
+
+- Shared global state with a minimal API
+- Optional persistence (`localStorage` on Web; storage adapters on React Native)
+- Debug logging for development (`debug` prop)
+- Composed hooks for common patterns (`useToggle`, `useCounter`, `useFormState`, …)
+- Storage adapter interface for custom backends
+
+## API Overview
+
+| Export | Kind | Description |
+| --- | --- | --- |
+| `useFusionState` | Hook | Subscribe to a global key; returns `[value, setValue]` |
+| `FusionStateProvider` | Component | Root provider for global state |
+| `useGlobalState` | Hook | Access the full global state context |
+| `useFusionStateLog` | Hook | Observe state slices for debugging |
+| `usePersistentState` | Hook | Like `useFusionState`, auto-prefixes keys with `persist.` |
+| `useFrequentState` | Hook | High-frequency updates with `skipLocalState: true` |
+| `useFormState` | Hook | Form object with field updater and reset |
+| `useCounter` | Hook | Counter with increment, decrement, and set |
+| `useToggle` | Hook | Boolean flag with toggle and set |
+| `createLocalStorageAdapter` | Function | Web `localStorage` adapter |
+| `createMemoryStorageAdapter` | Function | In-memory adapter (tests, ephemeral sessions) |
+| `createNoopStorageAdapter` | Function | No-op adapter (SSR-safe fallback) |
+| `detectBestStorageAdapter` | Function | Pick the best adapter for the current runtime |
+| `NoopStorageAdapter` | Function | Deprecated alias for `createNoopStorageAdapter` |
+| `formatErrorMessage` | Function | Substitute placeholders in error templates |
+| `debounce` | Function | Debounce a function |
+| `simpleDeepEqual` | Function | JSON-based deep equality check |
+| `FusionStateErrorMessages` | Enum | Stable library error message templates |
+| `FusionStateProviderProps` | Type | Props for `FusionStateProvider` |
+| `UseFusionStateOptions` | Type | Per-hook options (`skipLocalState`, …) |
+| `GlobalState` | Type | Global state record type |
+| `SetStateAction` | Type | Value or updater function |
+| `StateUpdater` | Type | Setter returned by `useFusionState` |
+| `GlobalFusionStateContextType` | Type | Context value from `useGlobalState` |
+| `FusionStatePersistenceProp` | Type | Accepted `persistence` prop shapes |
+| `SimplePersistenceConfig` | Type | Simplified persistence configuration |
+| `PersistenceConfig` | Type | Full persistence configuration |
+| `PersistenceKeys` | Type | `persistKeys` shapes (simple config) |
+| `PersistenceKeysConfig` | Type | `persistKeys` shapes (full config) |
+| `PersistenceKeyFilter` | Type | Filter predicate for persisted keys |
+| `StorageAdapter` | Type | Storage backend interface |
+| `FusionStateLogOptions` | Type | Options for `useFusionStateLog` |
+| `FusionStateLogSnapshot` | Type | Snapshot returned by `useFusionStateLog` |
+| `FusionStateLogKey` | Type | Key identifier for logging |
+
+## Persistence
+
+Persistence is optional. Pass a `persistence` prop to `FusionStateProvider`:
 
 ```jsx
-import { useFusionState } from 'react-fusion-state';
-
-function Compteur() {
-  // Fonctionne comme useState, mais partagé globalement
-  const [count, setCount] = useFusionState('counter', 0);
-  
-  return (
-    <div>
-      <p>Compteur: {count}</p>
-      <button onClick={() => setCount(count + 1)}>+</button>
-      <button onClick={() => setCount(count - 1)}>-</button>
-    </div>
-  );
-}
-```
-
-### 3. Accédez au même état depuis n'importe où
-
-```jsx
-function Affichage() {
-  // Utilise la même valeur 'counter' que le composant Compteur
-  const [count] = useFusionState('counter', 0);
-  
-  return <p>Valeur actuelle: {count}</p>;
-}
-```
-
-## Options
-
-### Persistance des données
-
-```jsx
-// Activez la persistance automatique (localStorage/AsyncStorage)
+// Enable persistence with defaults
 <FusionStateProvider persistence={true}>
   <App />
 </FusionStateProvider>
 
-// Persister uniquement certaines clés
+// Persist only selected keys
 <FusionStateProvider persistence={['user', 'theme']}>
   <App />
 </FusionStateProvider>
 ```
 
-### Mode debug
+When `persistence={true}` and no key filter is configured, only keys prefixed with `persist.` are saved by default. Use `usePersistentState` or prefix keys manually to opt in.
 
-```jsx
-// Activez le mode debug en développement
-<FusionStateProvider debug={true}>
-  <App />
-</FusionStateProvider>
-```
+For adapters, debounce, custom save/load, and React Native setup, see **[PERSISTENCE.md](./PERSISTENCE.md)**.
 
-## Utilisation avec React Native
+## TypeScript
 
-React Fusion State fonctionne parfaitement avec React Native sans configuration supplémentaire.
+Types are bundled in the published package (`dist/index.d.ts`). No `@types/*` install is required.
+
+- Generic inference: `useFusionState('count', 0)` infers `number`
+- Explicit generics: `useFusionState<User>('user', { name: '', email: '' })`
+- Provider props, persistence config, and storage adapters are fully typed
+- Exported public types (`StorageAdapter`, `PersistenceConfig`, `StateUpdater`, …) are available for application code
+
+## React Native
+
+React Fusion State works with React Native using the same hooks and provider.
 
 ```jsx
 import React from 'react';
 import { View, Text, Button } from 'react-native';
 import { FusionStateProvider, useFusionState } from 'react-fusion-state';
 
-// Composant de navigation
 function NavigationScreen() {
   const [screenData, setScreenData] = useFusionState('navigation.data', {});
-  
-  // Stockez des données pour d'autres écrans
+
   const navigateWithData = () => {
     setScreenData({ userId: 123, lastVisited: new Date() });
-    // ... puis naviguer vers l'écran suivant
+    // …then navigate to the next screen
   };
-  
+
   return (
     <View>
-      <Button title="Aller à l'écran Profil" onPress={navigateWithData} />
+      <Button title="Go to Profile" onPress={navigateWithData} />
     </View>
   );
 }
 
-// Composant profil sur un autre écran
 function ProfileScreen() {
-  // Accédez aux mêmes données, même sur un autre écran
   const [screenData] = useFusionState('navigation.data', {});
-  
+
   return (
     <View>
-      <Text>ID utilisateur: {screenData.userId}</Text>
-      <Text>Dernière visite: {screenData.lastVisited?.toString()}</Text>
+      <Text>User ID: {screenData.userId}</Text>
+      <Text>Last visit: {screenData.lastVisited?.toString()}</Text>
     </View>
   );
 }
 
-// Configuration avec persistance pour survivre aux redémarrages de l'app
 export default function App() {
   return (
-    <FusionStateProvider 
-      persistence={true}  // Utilise automatiquement AsyncStorage sur React Native
+    <FusionStateProvider
+      persistence={true}
       initialState={{
         'app.version': '1.0.0',
-        'user.settings': { notifications: true }
+        'user.settings': { notifications: true },
       }}
     >
-      {/* Votre navigation ou composants ici */}
+      {/* Your navigation or components here */}
     </FusionStateProvider>
   );
 }
 ```
 
-### Avantages spécifiques pour React Native
+### React Native notes
 
-- **Persistance automatique** - Utilise AsyncStorage sans configuration
-- **Partage entre écrans** - Évite de passer des props à travers la navigation 
-- **État cohérent** - Même après le démontage et remontage d'écrans
-- **Performance** - Optimisé pour éviter les re-rendus inutiles sur mobile
+- **Persistence** — pass a storage adapter explicitly on React Native when needed; see [PERSISTENCE.md](./PERSISTENCE.md)
+- **Cross-screen sharing** — avoid threading props through navigation stacks
+- **Stable state** — values survive screen unmount and remount within the same provider
 
-## Exemple complet
+## Examples
+
+### Debug mode
+
+```jsx
+<FusionStateProvider debug={true}>
+  <App />
+</FusionStateProvider>
+```
+
+Avoid enabling `debug` in production — logs may include user data.
+
+### Complete theme example
 
 ```jsx
 import React from 'react';
 import { FusionStateProvider, useFusionState } from 'react-fusion-state';
 
-// Composant qui modifie l'état
 function ThemeToggle() {
   const [theme, setTheme] = useFusionState('theme', 'light');
-  
+
   return (
     <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
       {theme === 'light' ? '🌙' : '☀️'}
@@ -168,25 +226,25 @@ function ThemeToggle() {
   );
 }
 
-// Composant qui utilise l'état
 function ThemedComponent() {
   const [theme] = useFusionState('theme', 'light');
-  
+
   return (
-    <div style={{ 
-      background: theme === 'light' ? '#fff' : '#333',
-      color: theme === 'light' ? '#333' : '#fff',
-      padding: '20px'
-    }}>
-      <h2>Thème: {theme}</h2>
+    <div
+      style={{
+        background: theme === 'light' ? '#fff' : '#333',
+        color: theme === 'light' ? '#333' : '#fff',
+        padding: '20px',
+      }}
+    >
+      <h2>Theme: {theme}</h2>
     </div>
   );
 }
 
-// Application
 function App() {
   return (
-    <FusionStateProvider 
+    <FusionStateProvider
       initialState={{ version: '1.0' }}
       persistence={true}
       debug={process.env.NODE_ENV === 'development'}
@@ -201,6 +259,10 @@ function App() {
 
 export default App;
 ```
+
+## Contributing
+
+Issues and pull requests are welcome on [GitHub](https://github.com/jgerard72/react-fusion-state).
 
 ## License
 


### PR DESCRIPTION
## Summary

Rewrites the project README for an international (English-first) audience and adds `README.fr.md` as a synchronized French mirror. No runtime, API, or version changes.

## Motivation

The previous README was French-only, omitted most public exports, and included unsupported bundle-size claims. npm and GitHub discovery benefit from an English landing page with API overview, TypeScript guidance, and links to deeper persistence docs.

## Changes

- Rewrite `readme.md` in English with badges, Quick Start, Core Concepts, API table, TypeScript, and Contributing sections
- Add `README.fr.md` — French mirror with identical structure
- Preserve existing examples (theme, React Native, debug, persistence)
- Link to `PERSISTENCE.md` for advanced persistence configuration
- Remove unsupported “2KB” performance claim; clarify `persist.` default and RN adapter guidance

## Validation

- Build: `npm run build` ✅
- Tests: `npm test` ✅ (37 passed)
- Type tests: `npm run test:types` ✅
- Lint: not run (pre-existing local `eslint-plugin-rulesdir` environment issue; docs-only diff)
- Manual validation: Markdown links verified (`PERSISTENCE.md`, GitHub, npm badges, EN/FR cross-links)

## Risks

- Low — documentation only; no consumer runtime impact
- npm may display `readme.md` (lowercase) as the package README depending on registry casing

## Rollback

Revert this commit. No migration or code changes required.

Made with [Cursor](https://cursor.com)