### PR TITLE
docs(examples): clean up reference examples for first-time users

### DIFF
--- a/src/examples/BasicExample.tsx
+++ b/src/examples/BasicExample.tsx
@@ -1,58 +1,49 @@
 import React from 'react';
-import {FusionStateProvider, useFusionState, useFusionStateLog} from '../index';
+import {
+  FusionStateProvider,
+  useFusionState,
+  useFusionStateLog,
+} from 'react-fusion-state';
 
-// Type pour les todo items
 interface Todo {
   id: number;
   text: string;
   completed: boolean;
 }
 
-// Counter Component using Fusion State
 function Counter() {
-  // Simple state with initial value
   const [count, setCount] = useFusionState<number>('counter', 0);
 
   return (
     <div className="counter">
       <h2>Counter: {count}</h2>
-      <button onClick={() => setCount(count + 1)}>Increment</button>
-      <button onClick={() => setCount(count - 1)}>Decrement</button>
+      <button onClick={() => setCount(c => c + 1)}>Increment</button>
+      <button onClick={() => setCount(c => c - 1)}>Decrement</button>
       <button onClick={() => setCount(0)}>Reset</button>
     </div>
   );
 }
 
-// Todo Component using Fusion State
 function TodoList() {
-  // Complex state with initial value
   const [todos, setTodos] = useFusionState<Todo[]>('todos', [
     {id: 1, text: 'Learn React', completed: true},
     {id: 2, text: 'Try React Fusion State', completed: false},
   ]);
-
-  // Form state
   const [newTodo, setNewTodo] = useFusionState<string>('newTodoText', '');
 
-  // Add new todo
   const addTodo = () => {
     if (!newTodo.trim()) return;
 
-    setTodos([
-      ...todos,
-      {
-        id: Date.now(),
-        text: newTodo,
-        completed: false,
-      },
+    setTodos(prev => [
+      ...prev,
+      {id: Date.now(), text: newTodo, completed: false},
     ]);
     setNewTodo('');
   };
 
-  // Toggle todo completion
   const toggleTodo = (id: number) => {
-    setTodos(
-      todos.map((todo: Todo) =>
+    setTodos(prev =>
+      prev.map(todo =>
         todo.id === id ? {...todo, completed: !todo.completed} : todo,
       ),
     );
@@ -61,7 +52,6 @@ function TodoList() {
   return (
     <div className="todo-list">
       <h2>Todo List</h2>
-
       <div className="add-todo">
         <input
           type="text"
@@ -71,9 +61,8 @@ function TodoList() {
         />
         <button onClick={addTodo}>Add</button>
       </div>
-
       <ul>
-        {todos.map((todo: Todo) => (
+        {todos.map(todo => (
           <li
             key={todo.id}
             style={{
@@ -89,9 +78,7 @@ function TodoList() {
   );
 }
 
-// StateDebugger using useFusionStateLog
 function StateDebugger() {
-  // Watch all state or specific keys
   const state = useFusionStateLog(['counter', 'todos'], {
     trackChanges: true,
     consoleLog: true,
@@ -106,33 +93,30 @@ function StateDebugger() {
   );
 }
 
-// Main App using FusionStateProvider
+function ThemeToggle() {
+  // `theme` is seeded by FusionStateProvider initialState below
+  const [theme, setTheme] = useFusionState<string>('theme');
+
+  return (
+    <div className="theme-toggle">
+      <button onClick={() => setTheme(t => (t === 'light' ? 'dark' : 'light'))}>
+        Switch to {theme === 'light' ? 'Dark' : 'Light'} Theme
+      </button>
+      <p>Current theme: {theme}</p>
+    </div>
+  );
+}
+
 export default function App() {
   return (
     <FusionStateProvider initialState={{theme: 'light'}} debug={true}>
       <div className="app">
         <h1>React Fusion State Example</h1>
-
         <Counter />
         <TodoList />
         <StateDebugger />
-
         <ThemeToggle />
       </div>
     </FusionStateProvider>
-  );
-}
-
-// Theme toggler component
-function ThemeToggle() {
-  const [theme, setTheme] = useFusionState<string>('theme');
-
-  return (
-    <div className="theme-toggle">
-      <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
-        Switch to {theme === 'light' ? 'Dark' : 'Light'} Theme
-      </button>
-      <p>Current theme: {theme}</p>
-    </div>
   );
 }

--- a/src/examples/ComposedHooksExample.tsx
+++ b/src/examples/ComposedHooksExample.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {
+  FusionStateProvider,
+  useCounter,
+  useToggle,
+  useFormState,
+  usePersistentState,
+} from 'react-fusion-state';
+
+interface SignupForm {
+  email: string;
+  name: string;
+}
+
+function LikesCounter() {
+  const [likes, increment] = useCounter('likes', 0);
+
+  return (
+    <div>
+      <h2>Likes: {likes}</h2>
+      <button onClick={increment}>Like</button>
+    </div>
+  );
+}
+
+function SidebarToggle() {
+  const [open, toggle] = useToggle('sidebar.open', false);
+
+  return (
+    <div>
+      <h2>Sidebar: {open ? 'Open' : 'Closed'}</h2>
+      <button onClick={toggle}>Toggle sidebar</button>
+    </div>
+  );
+}
+
+function SignupFormPanel() {
+  const [form, updateField, resetForm] = useFormState<SignupForm>('signup', {
+    email: '',
+    name: '',
+  });
+
+  return (
+    <div>
+      <h2>Signup</h2>
+      <label>
+        Email:
+        <input
+          value={form.email}
+          onChange={e => updateField('email', e.target.value)}
+        />
+      </label>
+      <label>
+        Name:
+        <input
+          value={form.name}
+          onChange={e => updateField('name', e.target.value)}
+        />
+      </label>
+      <button onClick={resetForm}>Reset</button>
+    </div>
+  );
+}
+
+function AuthTokenField() {
+  const [token, setToken] = usePersistentState('auth.token', '');
+
+  return (
+    <label>
+      Auth token:
+      <input
+        value={token}
+        onChange={e => setToken(e.target.value)}
+        placeholder="Saved under persist.auth.token"
+      />
+    </label>
+  );
+}
+
+export default function ComposedHooksApp() {
+  return (
+    <FusionStateProvider persistence={true}>
+      <div>
+        <h1>Composed Hooks</h1>
+        <LikesCounter />
+        <SidebarToggle />
+        <SignupFormPanel />
+        <AuthTokenField />
+      </div>
+    </FusionStateProvider>
+  );
+}

--- a/src/examples/PersistenceExample.tsx
+++ b/src/examples/PersistenceExample.tsx
@@ -1,186 +1,105 @@
-import React, {useState} from 'react';
-import {FusionStateProvider, useFusionState} from '../index';
-import {StorageAdapter} from '../storage/storageAdapters';
+import React from 'react';
+import {
+  FusionStateProvider,
+  useFusionState,
+  createLocalStorageAdapter,
+} from 'react-fusion-state';
 
-/**
- * Exemple d'adaptateur pour localStorage
- */
-class LocalStorageAdapter implements StorageAdapter {
-  async getItem(key: string): Promise<string | null> {
-    try {
-      return localStorage.getItem(key);
-    } catch (error) {
-      console.error('Error reading from localStorage:', error);
-      return null;
-    }
-  }
-
-  async setItem(key: string, value: string): Promise<void> {
-    try {
-      localStorage.setItem(key, value);
-    } catch (error) {
-      console.error('Error writing to localStorage:', error);
-    }
-  }
-
-  async removeItem(key: string): Promise<void> {
-    try {
-      localStorage.removeItem(key);
-    } catch (error) {
-      console.error('Error removing from localStorage:', error);
-    }
-  }
+interface Settings {
+  theme: string;
+  fontSize: string;
+  notifications: boolean;
 }
 
-/**
- * Exemple d'adaptateur pour React Native avec AsyncStorage
- * Vous devez installer @react-native-async-storage/async-storage
- *
- * Décommentez ce code pour l'utiliser dans React Native :
- */
-/*
-class AsyncStorageAdapter implements StorageAdapter {
-  async getItem(key: string): Promise<string | null> {
-    try {
-      // Importez AsyncStorage depuis le package adapté à votre projet
-      // import AsyncStorage from '@react-native-async-storage/async-storage';
-      return await AsyncStorage.getItem(key);
-    } catch (error) {
-      console.error('Error reading from AsyncStorage:', error);
-      return null;
-    }
-  }
-
-  async setItem(key: string, value: string): Promise<void> {
-    try {
-      await AsyncStorage.setItem(key, value);
-    } catch (error) {
-      console.error('Error writing to AsyncStorage:', error);
-    }
-  }
-
-  async removeItem(key: string): Promise<void> {
-    try {
-      await AsyncStorage.removeItem(key);
-    } catch (error) {
-      console.error('Error removing from AsyncStorage:', error);
-    }
-  }
-}
-*/
-
-// Composant Counter avec stockage persistant
 function PersistentCounter() {
   const [count, setCount] = useFusionState<number>('counter', 0);
 
   return (
     <div className="counter">
       <h2>Counter: {count}</h2>
-      <p>Ce compteur persiste après rechargement de la page !</p>
-      <button onClick={() => setCount(count + 1)}>Increment</button>
-      <button onClick={() => setCount(count - 1)}>Decrement</button>
+      <p>This counter survives page reloads.</p>
+      <button onClick={() => setCount(c => c + 1)}>Increment</button>
+      <button onClick={() => setCount(c => c - 1)}>Decrement</button>
       <button onClick={() => setCount(0)}>Reset</button>
     </div>
   );
 }
 
-// Settings avec stockage persistant mais sélectif
 function PersistentSettings() {
-  const [settings, setSettings] = useFusionState('settings', {
+  const [settings, setSettings] = useFusionState<Settings>('settings', {
     theme: 'light',
     fontSize: 'medium',
     notifications: true,
   });
 
-  const updateSetting = (key: string, value: any) => {
-    setSettings({...settings, [key]: value});
+  const updateSetting = <K extends keyof Settings>(key: K, value: Settings[K]) => {
+    setSettings(prev => ({...prev, [key]: value}));
   };
 
   return (
     <div className="settings">
       <h2>Settings</h2>
-      <p>Ces paramètres persistent, ils sont inclus dans persistKeys</p>
-
-      <div>
-        <label>
-          Theme:
-          <select
-            value={settings.theme}
-            onChange={e => updateSetting('theme', e.target.value)}>
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-            <option value="system">System</option>
-          </select>
-        </label>
-      </div>
-
-      <div>
-        <label>
-          Font Size:
-          <select
-            value={settings.fontSize}
-            onChange={e => updateSetting('fontSize', e.target.value)}>
-            <option value="small">Small</option>
-            <option value="medium">Medium</option>
-            <option value="large">Large</option>
-          </select>
-        </label>
-      </div>
-
-      <div>
-        <label>
-          <input
-            type="checkbox"
-            checked={settings.notifications}
-            onChange={e => updateSetting('notifications', e.target.checked)}
-          />
-          Enable Notifications
-        </label>
-      </div>
+      <p>Included in persistKeys — saved on change.</p>
+      <label>
+        Theme:
+        <select
+          value={settings.theme}
+          onChange={e => updateSetting('theme', e.target.value)}>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          <option value="system">System</option>
+        </select>
+      </label>
+      <label>
+        Font size:
+        <select
+          value={settings.fontSize}
+          onChange={e => updateSetting('fontSize', e.target.value)}>
+          <option value="small">Small</option>
+          <option value="medium">Medium</option>
+          <option value="large">Large</option>
+        </select>
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={settings.notifications}
+          onChange={e => updateSetting('notifications', e.target.checked)}
+        />
+        Enable notifications
+      </label>
     </div>
   );
 }
 
-// Données temporaires - non persistantes
 function TemporaryData() {
   const [tempData, setTempData] = useFusionState('tempData', {
     searchQuery: '',
     lastUpdated: new Date().toISOString(),
   });
 
-  const updateSearch = (query: string) => {
-    setTempData({
-      ...tempData,
-      searchQuery: query,
-      lastUpdated: new Date().toISOString(),
-    });
-  };
-
   return (
     <div className="temp-data">
       <h2>Temporary Data</h2>
-      <p>
-        Ces données ne persistent pas, car 'tempData' n'est pas dans persistKeys
-      </p>
-
+      <p>Not in persistKeys — cleared on reload.</p>
       <input
         type="text"
         value={tempData.searchQuery}
-        onChange={e => updateSearch(e.target.value)}
+        onChange={e =>
+          setTempData(prev => ({
+            ...prev,
+            searchQuery: e.target.value,
+            lastUpdated: new Date().toISOString(),
+          }))
+        }
         placeholder="Search query (not persisted)"
       />
-
-      <p>Last Updated: {new Date(tempData.lastUpdated).toLocaleTimeString()}</p>
+      <p>Last updated: {new Date(tempData.lastUpdated).toLocaleTimeString()}</p>
     </div>
   );
 }
 
-// Application principale avec persistance configurée
 export default function PersistenceApp() {
-  // Créez votre adaptateur de stockage
-  const storageAdapter = new LocalStorageAdapter();
-  // Pour React Native, utilisez AsyncStorageAdapter
-
   return (
     <FusionStateProvider
       initialState={{
@@ -197,18 +116,16 @@ export default function PersistenceApp() {
       }}
       debug={true}
       persistence={{
-        adapter: storageAdapter,
+        adapter: createLocalStorageAdapter(),
         keyPrefix: 'myapp',
-        // Uniquement persister counter et settings, pas tempData
         persistKeys: ['counter', 'settings'],
         loadOnInit: true,
         saveOnChange: true,
-        debounceTime: 300, // Attend 300ms avant de sauvegarder
+        debounceTime: 300,
       }}>
       <div className="persistence-example">
-        <h1>React Fusion State avec Persistence</h1>
-        <p>Rafraîchissez la page pour voir les valeurs persister !</p>
-
+        <h1>React Fusion State — Advanced Persistence</h1>
+        <p>Reload the page to verify persisted keys.</p>
         <PersistentCounter />
         <PersistentSettings />
         <TemporaryData />

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -1,0 +1,38 @@
+# Examples
+
+Reference examples for **react-fusion-state**. These files are not published to npm and are not runnable on their own — copy them into your React app or read them alongside the [README](../../readme.md).
+
+## How to use
+
+1. Install the library in your app:
+
+   ```bash
+   npm install react-fusion-state
+   ```
+
+2. Copy a component file (or parts of it) into your project.
+
+3. Keep imports as:
+
+   ```tsx
+   import { FusionStateProvider, useFusionState } from 'react-fusion-state';
+   ```
+
+4. Wrap your app with `<FusionStateProvider>` once.
+
+For persistence details, see [PERSISTENCE.md](../../PERSISTENCE.md).
+
+## Files
+
+| File | What it shows |
+| --- | --- |
+| [BasicExample.tsx](./BasicExample.tsx) | Counter, todo list, `useFusionStateLog`, provider `initialState` |
+| [SimplePersistenceExample.tsx](./SimplePersistenceExample.tsx) | `persistence={true}` and `persistence={['theme']}` |
+| [PersistenceExample.tsx](./PersistenceExample.tsx) | Full `PersistenceConfig` with `createLocalStorageAdapter()` and selective keys |
+| [ComposedHooksExample.tsx](./ComposedHooksExample.tsx) | `useCounter`, `useToggle`, `useFormState`, `usePersistentState` |
+
+## Notes
+
+- Examples use public imports only (`react-fusion-state`), matching consumer code.
+- CSS class names are placeholders — add your own styles.
+- React Native: use the same hooks; pass a storage adapter when enabling persistence (see [PERSISTENCE.md](../../PERSISTENCE.md)).

--- a/src/examples/SimplePersistenceExample.tsx
+++ b/src/examples/SimplePersistenceExample.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  FusionStateProvider,
+  useFusionState,
+  usePersistentState,
+} from 'react-fusion-state';
+
+function ThemePanel() {
+  const [theme, setTheme] = useFusionState<'light' | 'dark'>('theme', 'light');
+
+  return (
+    <div>
+      <h2>Theme: {theme}</h2>
+      <button onClick={() => setTheme(t => (t === 'light' ? 'dark' : 'light'))}>
+        Toggle theme
+      </button>
+    </div>
+  );
+}
+
+function SessionBanner() {
+  const [draft] = useFusionState<string>('draft', '');
+
+  return (
+    <p>
+      Draft (not persisted with key list): {draft || '(empty)'}
+    </p>
+  );
+}
+
+/** persistence={['theme']} — persist only listed keys */
+export function PersistenceKeyListApp() {
+  return (
+    <FusionStateProvider persistence={['theme']}>
+      <div>
+        <h1>Persistence — key list</h1>
+        <ThemePanel />
+        <SessionBanner />
+      </div>
+    </FusionStateProvider>
+  );
+}
+
+function AuthToken() {
+  const [token, setToken] = usePersistentState('auth.token', '');
+
+  return (
+    <label>
+      Token (persisted via persist. prefix):
+      <input
+        type="text"
+        value={token}
+        onChange={e => setToken(e.target.value)}
+        placeholder="Enter token"
+      />
+    </label>
+  );
+}
+
+/** persistence={true} — default filter saves keys prefixed with persist. */
+export function PersistenceDefaultApp() {
+  return (
+    <FusionStateProvider persistence={true}>
+      <div>
+        <h1>Persistence — defaults</h1>
+        <AuthToken />
+      </div>
+    </FusionStateProvider>
+  );
+}
+
+export default PersistenceKeyListApp;


### PR DESCRIPTION
## Summary

Cleans up `src/examples/` so reference code is copy/paste friendly for first-time users: public imports, English labels, functional updaters, and canonical storage factories. Adds an examples README plus simple persistence and composed-hooks samples.

## Motivation

Existing examples used internal imports (`../index`, `../storage/...`), hand-rolled storage adapters, and mixed French/English copy. They were hard to reuse without rewriting and did not reflect the public API documented in the README.

## Changes

- Add `src/examples/README.md` with usage guide and file index
- Update `BasicExample.tsx` — `react-fusion-state` imports, functional updaters
- Update `PersistenceExample.tsx` — `createLocalStorageAdapter()`, typed settings, English UI
- Add `SimplePersistenceExample.tsx` — `persistence={true}` and `persistence={['theme']}`
- Add `ComposedHooksExample.tsx` — `useCounter`, `useToggle`, `useFormState`, `usePersistentState`

## Validation

- Build: `npm run build` ✅
- Tests: `npm test` ✅ (37 passed)
- Type tests: `npm run test:types` ✅
- Lint: not run (pre-existing local `eslint-plugin-rulesdir` environment issue; examples-only diff)
- Manual validation: examples excluded from npm bundle and build output

## Risks

- Low — documentation/reference files only; no runtime or API changes
- Examples are not runnable standalone (by design for this PR)

## Rollback

Revert this commit. No consumer migration required.

Made with [Cursor](https://cursor.com)