### PR TITLE
test: add parsePublicApiExports helper for public API tests

### DIFF
--- a/src/__tests__/helpers/parsePublicApiExports.ts
+++ b/src/__tests__/helpers/parsePublicApiExports.ts
@@ -1,0 +1,34 @@
+/**
+ * Parse the public `export { … }` block from a generated declaration file.
+ */
+export function parseDeclarationExportBlock(source: string): {
+  values: string[];
+  types: string[];
+} {
+  const match = source.match(/^export\s*\{([^}]+)\}/m);
+  if (!match) {
+    throw new Error('Could not find public export block in declaration file');
+  }
+
+  const values: string[] = [];
+  const types: string[] = [];
+
+  for (const rawPart of match[1].split(',')) {
+    const part = rawPart.trim();
+    if (!part) {
+      continue;
+    }
+
+    const typeMatch = part.match(/^type\s+(\w+)$/);
+    if (typeMatch) {
+      types.push(typeMatch[1]);
+    } else {
+      values.push(part);
+    }
+  }
+
+  return {
+    values: values.sort(),
+    types: types.sort(),
+  };
+}


### PR DESCRIPTION
## Summary

Adds the missing `parsePublicApiExports` test helper used by `public-api.test.ts`.

## Motivation

`public-api.test.ts` imports `./helpers/parsePublicApiExports`, but the helper was never committed. Fresh clones would fail the public API contract tests unless the file existed locally.

## Changes

- Add `src/__tests__/helpers/parsePublicApiExports.ts`

## Validation

- Build: `npm run build` ✅
- Tests: `npm test` ✅ (37 passed)
- Type tests: `npm run test:types` ✅
- Lint: not run (pre-existing local environment issue; test-helper-only diff)
- Manual validation: helper matches import in `public-api.test.ts`

## Risks

- None — test infrastructure only; no runtime or public API changes

## Rollback

Revert this commit. No consumer impact.

Made with [Cursor](https://cursor.com)